### PR TITLE
Fix config env check, type hints, email context, and query safety

### DIFF
--- a/clients/exchange_utils.py
+++ b/clients/exchange_utils.py
@@ -17,7 +17,7 @@ def ccxt_exchanges(ccxt_module: Optional[CcxtModuleType] = None) -> list[str]:
     return ccxt_module.exchanges if ccxt_module is not None else ccxt.exchanges
 
 
-def format_pair(symbol, quote_ccy, divider: None) -> str:
+def format_pair(symbol: str, quote_ccy: str, divider: str = "") -> str:
     return f"{symbol}{divider}{quote_ccy}"
 
 

--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ class Config:
             bybit_api_key = os.getenv("BYBIT_TEST_APIKEY")
             bybit_secret = os.getenv("BYBIT_TEST_SECRET")
 
-        elif self.env == "prod":
+        elif self.env_name == "prod":
             binance_api_key = os.getenv("BINANCE_PROD_APIKEY")
             binance_secret = os.getenv("BINANCE_PROD_SECRET")
             kraken_api_key = os.getenv("KRAKEN_PROD_APIKEY")

--- a/database/models.py
+++ b/database/models.py
@@ -31,7 +31,8 @@ class Order:
         JOIN moolah.coin c ON s.coin_id = c.id
         """
 
-        conditions = []
+        conditions: list[str] = []
+        params: list[str] = []
 
         if has_external_id is not None:
             if has_external_id:
@@ -40,16 +41,17 @@ class Order:
                 conditions.append("(o.external_order_id IS NULL OR o.external_order_id = '')")
 
         if status is not None:
-            conditions.append(f"o.status = '{status}'")
+            conditions.append("o.status = %s")
+            params.append(status)
 
         if market_code is not None:
-            conditions.append(f"o.market_code = '{market_code}'")
+            conditions.append("o.market_code = %s")
+            params.append(market_code)
 
         if conditions:
-            sql_query += " WHERE " + " AND ".join(conditions) + ";"
-        else:
-            sql_query += ";"
-        cur.execute(sql_query)
+            sql_query += " WHERE " + " AND ".join(conditions)
+        sql_query += ";"
+        cur.execute(sql_query, params)
         columns = [desc[0] for desc in cur.description]
         rows = cur.fetchall()
         results = [dict(zip(columns, row, strict=False)) for row in rows]

--- a/email_services.py
+++ b/email_services.py
@@ -1,32 +1,41 @@
+from flask import Flask
 from flask_mail import Mail, Message
 from config import Config
 
 
-def send_email(subject: str, body: str, recipients: list[str] = None):
+def send_email(subject: str, body: str, recipients: list[str] | None = None):
     config = Config()
-    mail = Mail()
+    app = Flask(__name__)
+    app.config.update(
+        MAIL_SERVER=config.mail_server,
+        MAIL_PORT=config.mail_port,
+        MAIL_USE_TLS=config.mail_use_tls,
+        MAIL_USERNAME=config.mail_username,
+        MAIL_PASSWORD=config.mail_password,
+        MAIL_DEFAULT_SENDER=config.mail_default_sender,
+    )
+    mail = Mail(app)
     msg = Message(
         subject=subject,
         recipients=recipients if recipients else config.recipients,
         body=body,
     )
-    mail.send(msg)
+    with app.app_context():
+        mail.send(msg)
 
 
 def send_insufficient_funds_email(order, exchange_name, balance, total_order_value, balance_coin):
-    subject = ("Order Execution Failed Due to Insufficient Funds",)
+    subject = "Order Execution Failed Due to Insufficient Funds"
     body = (
-        (
-            f"Order Details:\n"
-            f"- Exchange: {exchange_name}\n"
-            f"- Order ID: {order['id']}\n"
-            f"- Order Type: {order['type']}\n"
-            f"- Side: {order['side']}\n"
-            f"- Amount: {order['amount']}\n"
-            f"- Symbol: {order['coin_code']}\n"
-            f"- Available Balance: {balance} {balance_coin}\n"
-            f"- Required Balance: {total_order_value} {balance_coin}\n\n"
-            f"Please ensure sufficient funds are available to execute the order."
-        ),
+        f"Order Details:\n"
+        f"- Exchange: {exchange_name}\n"
+        f"- Order ID: {order['id']}\n"
+        f"- Order Type: {order['type']}\n"
+        f"- Side: {order['side']}\n"
+        f"- Amount: {order['amount']}\n"
+        f"- Symbol: {order['coin_code']}\n"
+        f"- Available Balance: {balance} {balance_coin}\n"
+        f"- Required Balance: {total_order_value} {balance_coin}\n\n"
+        "Please ensure sufficient funds are available to execute the order."
     )
     send_email(subject, body)


### PR DESCRIPTION
## Summary
- fix Config to use env_name when selecting production keys
- clarify format_pair type hints and default divider
- send emails within Flask app context and fix insufficient funds template
- parameterize status and market code in get_all_orders to avoid SQL injection

## Testing
- `ruff format config.py clients/exchange_utils.py email_services.py database/models.py` *(fails: invalid array expected `]` in pyproject.toml)*
- `pytest -q` *(fails: 57 failed, 52 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688de21114f88328a66aea3d3954a7bc